### PR TITLE
Add React Native Polyfill

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,10 +5,10 @@ var minimongo = require('minimongo-cache');
 var EventEmitter = require('events').EventEmitter;
 var EJSON = require("ejson");
 
-// Polyfill for process.nextTick
 if (typeof this.process === 'undefined') {
-  process = {};
-  process.nextTick = setImmediate;
+  this.process = {
+    nextTick: setImmediate
+  };
 }
 
 class DDPClient extends EventEmitter{

--- a/index.js
+++ b/index.js
@@ -5,6 +5,12 @@ var minimongo = require('minimongo-cache');
 var EventEmitter = require('events').EventEmitter;
 var EJSON = require("ejson");
 
+// Polyfill for process.nextTick
+if (typeof this.process === 'undefined') {
+  process = {};
+  process.nextTick = setImmediate;
+}
+
 class DDPClient extends EventEmitter{
   constructor(opts) {
     super();

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "underscore": "1.8.3",
     "events": "1.0.2",
     "ejson": "2.0.1",
-    "minimongo-cache": "0.0.24"
+    "minimongo-cache": "0.0.25"
   },
   "author": "Harrison Harnisch <hharnisc@gmail.com>",
   "license": "MIT",


### PR DESCRIPTION
`process` isn't available in React Native and `minimongo-cache` needs `process.nextTick` so this adds a polyfill for that per instructions https://github.com/petehunt/minimongo-cache#react-native-pollyfill

Also bumped the `minimongo-cache` version
