### PR TITLE
(feat) adds promisified constructor, fixes #10 and #11, bumps minor version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ ddpclient.call("login", [
 
 ```js
 var DDPClient = require("ddp-client");
+// or "ddp-client/promise" for promisified versions of all async functions
 
 var ddpclient = new DDPClient({
   // All properties optional, defaults shown

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ddp-client",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "DDP Client for browsers and native JS runtimes (no dependencies on document or 3rd party WebSocket libraries)",
   "main": "index.js",
   "keywords": [

--- a/promise.js
+++ b/promise.js
@@ -1,0 +1,73 @@
+"use strict";
+
+let DDPClient = require('./index.js');
+
+class DDP extends DDPClient {
+  constructor(opts) {
+    super(opts);
+  }
+
+  connect() {
+    return new Promise((resolve, reject) => {
+      super.connect((err, wasReconnect) => {
+        if (err) {
+          console.log('DDP connection error!');
+          return reject(err);
+        }
+
+        if (wasReconnect) {
+          console.log('Reestablishment of a connection.');
+        }
+
+        console.log('connected to Meteor server');
+        resolve(this._isReconnecting);
+      });
+    });
+  }
+
+  call(name, params) {
+    return new Promise((resolve, reject) => {
+      super.call(name, params, (err, res) => {
+        if (err) {
+          reject(err);
+        } else { 
+          resolve(res);
+        }
+      }, () => {
+        // callback which fires when server has finished
+      });
+    });
+  }
+
+  callWithRandomSeed(name, params, randomSeed) {
+    return new Promise((resolve, reject) => {
+      super.callWithRandomSeed(name, params, randomSeed, (err, res) => {
+        if (err) { r
+          reject(err);
+        } else { 
+          resolve(res);
+        }
+      }, () => {
+        // callback which fires when server has finished
+      });
+    });
+  }
+
+  subscribe(...args) {
+    return super.subscribe(...args);
+  }
+
+  unsubscribe(...args) {
+    return super.unsubscribe(...args);
+  }
+
+  close() {
+    return super.close();
+  }
+
+  observe(...args) {
+    return super.observe(...args);
+  }
+}
+
+module.exports = DDP;


### PR DESCRIPTION
In reference to #10 and #11, this restores the observer methods `added`, `changed` and `removed` to the `observer` object and calls them when handling their corresponding DDP messages.

This also fixes a mismatch between the naming convention `changed` and `updated` that wasn't resolved in #11; the observer now has a method `changed` by default that is called when receiving DDP messages of the type "`changed`".
