### PR TITLE
Fix adding changed handler on observer creator

### DIFF
--- a/index.js
+++ b/index.js
@@ -450,10 +450,10 @@ class DDPClient extends EventEmitter{
   /**
    * Adds an observer to a collection and returns the observer.
    * Observation can be stopped by calling the stop() method on the observer.
-   * Functions for added, updated and removed can be added to the observer
+   * Functions for added, changed and removed can be added to the observer
    * afterward.
    */
-  observe(name, added, updated, removed) {
+  observe(name, added, changed, removed) {
     var self = this;
     var observer = {};
     var id = self._getNextId();
@@ -467,7 +467,7 @@ class DDPClient extends EventEmitter{
     Object.defineProperty(observer, "_id", { get: function() { return id; }});
 
     observer.added   = added   || function(){};
-    observer.updated = updated || function(){};
+    observer.changed = changed || function(){};
     observer.removed = removed || function(){};
 
     observer.stop = function() {


### PR DESCRIPTION
The DDP message parser is looking for an `observer.changed` function, but if you register a `changed` function via the `observe` function as the third argument, it gets registered as `updated` instead of `changed` and will throw when an update comes through.
