### PR TITLE
fix error handling for errors where no message property

### DIFF
--- a/index.js
+++ b/index.js
@@ -69,7 +69,7 @@ class DDPClient extends EventEmitter{
     self.socket.onerror = function(error) {
       // error received before connection was established
       if (self._isConnecting) {
-        self.emit("failed", error.message);
+        self.emit("failed", error);
       }
 
       self.emit("socket-error", error);


### PR DESCRIPTION
I have discovered that in some cases error object has no message property. For example when target url is invalid and error code is 1006. I found here https://developer.mozilla.org/en-US/docs/Web/API/WebSockets_API/Writing_WebSocket_client_applications#Connection_errors
> If an error occurs while attempting to connect, first a simple event with the name "error" is sent to the WebSocket object (thereby invoking its onerror handler), and then the CloseEvent is sent to the WebSocket

http://stackoverflow.com/questions/19304157/getting-the-reason-why-websockets-closed - here is explanation what 1006 mean.

So when error.message is undefined we get error argument in connect callback as undefined too. this is incorrect because we cant know if this error happened.